### PR TITLE
Add prompt generation script using Florence-2 and Groq

### DIFF
--- a/generate_florence_prompt.py
+++ b/generate_florence_prompt.py
@@ -1,0 +1,85 @@
+import argparse
+import os
+from PIL import Image
+from transformers import pipeline
+import groq
+
+SYSTEM_PROMPT = """System Prompt: Skyreels Optimized Motion Video Prompt Generator
+
+You are an AI assistant specialized in generating highly detailed, structured, and dynamic motion video prompts for Skyreels, the latest I2V model based on Hunyuan. Your task is to craft cinematically precise prompts that describe realistic, engaging, and fluid 5-8 second video scenes in 160 tokens or less.
+
+Key Requirements for Every Prompt:
+Start with “FPS-24, ”
+
+Every prompt must begin with FPS-24, to ensure compatibility with Skyreels' video generation model.
+Use Video Terminology
+
+Replace any references to "image," "photo," "illustration," or "picture" with "video," "scene," "footage," or "clip."
+Example: Instead of "The image shows a tiger running," write "The video captures a tiger sprinting across the jungle."
+Ensure Cinematic Motion & Camera Work
+
+Describe how the subject moves and how the camera follows the action.
+Use filmmaking terms like tracking shot, dolly zoom, slow-motion, aerial shot, handheld camera, or panning.
+Example: "The camera smoothly tracks the galloping horse, capturing dust rising beneath its hooves in slow motion."
+Enhance Atmosphere with Lighting & Mood
+
+Clearly define lighting conditions and how they affect the mood.
+Example: "Golden sunlight streams through the dense jungle, casting dappled patterns on the tiger's fur as it sprints forward."
+Include Background & Environmental Details
+
+Describe where the action takes place to create immersive world-building.
+Example: "Towering mountains loom in the distance as mist swirls around the warrior's feet."
+Use Evocative Language for Vivid Motion
+
+Avoid generic verbs like "moves" or "goes"; instead, use "glides," "races," "surges," "drifts," "pulses," or "twirls."
+Example: "The futuristic drone hovers weightlessly, then suddenly zips through neon-lit skyscrapers, leaving a streak of blue light in its wake."
+Maintain Logical & Visually Cohesive Flow
+
+Ensure lighting, colors, and movements remain consistent across the scene.
+Example: Don't mix "soft morning light" with "intense cyberpunk neon glow."
+Final Prompt Structure:
+
+Every generated prompt should follow a natural, cinematic flow, incorporating all essential elements:
+
+Example of a Perfect Skyreels Motion Video Prompt:
+FPS-24, A towering, armored warlord with glowing red eyes and curved horns strides forward through a battlefield of smoldering ruins, his massive flaming battle-axe crackling with embers as he swings it through the air. His heavy black and gold-plated armor glints under the flickering firelight, while his crimson cape whips violently behind him. In his other hand, he raises a massive shield adorned with a skull, its eyes pulsing with an eerie red glow. The camera starts with a tight close-up on his menacing face, then tilts down to follow the fluid motion of his axe as it carves through the smoky air. Small embers swirl around him, and the ground trembles with each of his powerful steps, enhancing the apocalyptic, battle-hardened atmosphere. The lighting casts deep, ominous shadows, emphasizing his unstoppable presence as he marches relentlessly forward, a true harbinger of destruction."""
+
+
+def describe_image(image_path: str) -> str:
+    """Generate a caption for an image using Microsoft Florence 2 Large."""
+    captioner = pipeline("image-to-text", model="microsoft/florence-2-large")
+    image = Image.open(image_path).convert("RGB")
+    result = captioner(image)
+    return result[0]["generated_text"].strip()
+
+
+def generate_prompt(caption: str, api_key: str) -> str:
+    """Call Groq API with the caption as user prompt and return the response."""
+    client = groq.Groq(api_key=api_key)
+    response = client.chat.completions.create(
+        model="llama-3.3-70b-versatile",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": caption},
+        ],
+        max_tokens=200,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Skyreels prompt from image")
+    parser.add_argument("image", help="Path to the input image")
+    parser.add_argument("--api-key", dest="api_key", default=os.getenv("GROQ_API_KEY"), help="Groq API key")
+    args = parser.parse_args()
+
+    if not args.api_key:
+        raise ValueError("Groq API key must be provided via --api-key or GROQ_API_KEY env var")
+
+    caption = describe_image(args.image)
+    prompt = generate_prompt(caption, args.api_key)
+    print(prompt)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ flash_attn
 numpy>=1.23.5,<2
 xfuser
 requests
+groq


### PR DESCRIPTION
## Summary
- add script `generate_florence_prompt.py` to caption an image using Microsoft Florence 2 Large
- call Groq's API with model `llama-3.3-70b-versatile` using the caption
- add `groq` to requirements

## Testing
- `python -m py_compile generate_florence_prompt.py`
- `python generate_florence_prompt.py --help`


------
https://chatgpt.com/codex/tasks/task_e_686931b3679083279008c24ce2ae7433