### PR TITLE
Interactive prompt support for image generation

### DIFF
--- a/generate_image.py
+++ b/generate_image.py
@@ -1,11 +1,13 @@
-import torch
 import os
+import sys
+
+import torch
 from diffusers import AutoPipelineForText2Image
+from huggingface_hub import login
+from peft import PeftConfig
+from peft import PeftModel
 
 # PEFT 라이브러리 필요 (LoRA 로딩용)
-from peft import PeftModel, PeftConfig
-
-from huggingface_hub import login
 
 login(os.environ.get("HUGGING_API_KEY"))
 
@@ -17,38 +19,40 @@ print(device)
 # 기본 모델 로드
 print("기본 FLUX 모델 로드 중...")
 pipe = AutoPipelineForText2Image.from_pretrained(
-    "black-forest-labs/FLUX.1-dev", 
-    torch_dtype=torch.float16  # bfloat16 대신 float16 사용
+    "black-forest-labs/FLUX.1-dev", torch_dtype=torch.float16  # bfloat16 대신 float16 사용
 )
 pipe.enable_model_cpu_offload()
 pipe.to(device)
 
 # Uncensored LoRA 로드
 print("Uncensored LoRA 로드 중...")
-pipe.load_lora_weights(
-    'Heartsync/Flux-NSFW-uncensored', 
-    weight_name='lora.safetensors',
-    adapter_name="uncensored"
-)
+pipe.load_lora_weights("Heartsync/Flux-NSFW-uncensored", weight_name="lora.safetensors", adapter_name="uncensored")
 
 # 이미지 생성
-prompt = sys.argv[1]
 negative_prompt = "text, watermark, signature, cartoon, anime, illustration, painting, drawing, low quality, blurry"
 
 # 시드 설정
 seed = 42
 generator = torch.Generator(device=device).manual_seed(seed)
 
-# 이미지 생성
-image = pipe(
-    prompt=prompt,
-    negative_prompt=negative_prompt,
-    guidance_scale=7.0,
-    num_inference_steps=28,
-    width=544,
-    height=960,
-    generator=generator,
-).images[0]
+while True:
+    try:
+        prompt = input("Enter prompt (blank to exit): ").strip()
+    except EOFError:
+        break
 
-# 이미지 저장
-image.save("generated_image.png")
+    if not prompt:
+        break
+
+    image = pipe(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        guidance_scale=7.0,
+        num_inference_steps=28,
+        width=544,
+        height=960,
+        generator=generator,
+    ).images[0]
+
+    image.save("generated_image.png")
+    print("generated_image.png saved")


### PR DESCRIPTION
## Summary
- turn `generate_image.py` into an interactive script
- load model once and prompt repeatedly

## Testing
- `pre-commit run --files generate_image.py`

------
https://chatgpt.com/codex/tasks/task_e_6878d6ebddd48327acf03a268c0cc21d